### PR TITLE
Guidelines matrix: Link fix und neutralere Formulierungen

### DIFF
--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -1,20 +1,19 @@
 Es gibt folgende Matrix-Räume:
 - FOSS-AG Hauptkanal (öffentlich)
   - Es gibt einen Admin
-  - Jede aktive Person kann Moderator-Rechte erhalten
+  - Jede aktives Mitglied kann Moderator-Rechte erhalten
   - Themen:
     - FOSS-AG Aktivitäten
     - FOSS-Themen
     - Vorstellung von Teams, Events, etc.
-- FOSS-AG Orga (nur Aktive-Mitglieder)
+- FOSS-AG Orga (nur aktive Mitglieder)
   - Es gibt einen Admin
   - Themen:
     - Absprache von Terminfindungen/Raumorganisation
-    - Vorschlagen potentieller neuer aktiver Personen
-      - Ein Aufnahme-Moratorium für den aktuellen Tag bietet Möglichkeit der Diskussion über die Aufnahme
+    - Vorschlagen potentieller neuer aktiver Mitglieder -> Aufnahme nach Abstimmung mit weiteren aktiven Mitgliedern
     - Diskussionen die persönliche Daten enthalten (z.B. Roh-Fotos von Events)
     - Keine allgemeinen Themen -> offener Kanal
 - Weitere Räume für Teams
 - Schema:
-  - Name: FOSS-AG <Titel>
+  - Name: FOSS-AG \<Titel\>
   - Logo: FOSS-AG Logo oder vom Grafik-Team abgenickt

--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -1,19 +1,20 @@
 Es gibt folgende Matrix-Räume:
 - FOSS-AG Hauptkanal (öffentlich)
   - Es gibt einen Admin
-  - Jeder Aktive kann Moderator-Rechte erhalten
+  - Jede aktive Person kann Moderator-Rechte erhalten
   - Themen:
     - FOSS-AG Aktivitäten
     - FOSS-Themen
-    - Vorstellung von Teams, Events etc.
+    - Vorstellung von Teams, Events, etc.
 - FOSS-AG Orga (nur Aktive-Mitglieder)
   - Es gibt einen Admin
   - Themen:
     - Absprache von Terminfindungen/Raumorganisation
-    - Vorstellung potenzieller neuer Aktiver -> Möglichkeit der Diskussion (Veto-Möglichkeit für den aktuellen Tag)
-    - Diskusionnen die persönliche Daten enthalten (z.B. Roh-Fotos von Events)
+    - Vorstellung potentieller neuer aktiver Personen
+      - Möglichkeit der Diskussion (Veto-Moratorium für den Rest des aktuellen Tages)
+    - Diskussionen die persönliche Daten enthalten (z.B. Roh-Fotos von Events)
     - Keine allgemeinen Themen -> offener Kanal
 - Weitere Räume für Teams
 - Schema:
   - Name: FOSS-AG <Titel>
-  - Logo: FOSS-AG Logo oder vom Grafik-Team angenickt
+  - Logo: FOSS-AG Logo oder vom Grafik-Team abgenickt

--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -10,8 +10,8 @@ Es gibt folgende Matrix-Räume:
   - Es gibt einen Admin
   - Themen:
     - Absprache von Terminfindungen/Raumorganisation
-    - Vorstellung potentieller neuer aktiver Personen
-      - Möglichkeit der Diskussion (Veto-Moratorium für den Rest des aktuellen Tages)
+    - Vorschlagen potentieller neuer aktiver Personen
+      - Ein Aufnahme-Moratorium für den aktuellen Tag bietet Möglichkeit der Diskussion über die Aufnahme
     - Diskussionen die persönliche Daten enthalten (z.B. Roh-Fotos von Events)
     - Keine allgemeinen Themen -> offener Kanal
 - Weitere Räume für Teams

--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -1,7 +1,7 @@
 Es gibt folgende Matrix-Räume:
 - FOSS-AG Hauptkanal (öffentlich)
   - Es gibt einen Admin
-  - Jede aktives Mitglied kann Moderator-Rechte erhalten
+  - Jedes aktive Mitglied kann Moderator-Rechte erhalten
   - Themen:
     - FOSS-AG Aktivitäten
     - FOSS-Themen


### PR DESCRIPTION
`orga_guidelines.md`:

- Ersetze Veto-Möglichkeit durch Veto-Moratorium: Moratorium impliziert, dass die Umsetzung für mögliche Vetos ausgesetzt wird.
- Verwende neutralere Begriffe für eine Person.
- Typo fixes.