### PR TITLE
Minor markdownlint fixes.

### DIFF
--- a/doc/guidelines_foss-ag.md
+++ b/doc/guidelines_foss-ag.md
@@ -1,12 +1,15 @@
+# Guidelines FOSS-AG
+
 Es gibt folgende Rollen einer Personen:
+
 - Mitglied/Besucher:
-    - Jeder der möchte.
-    - Mitarbeit an allen Projekten (z.B. PRs auf GH, Beteiligung bei Teams etc.) ist erwünscht!
+  - Jeder der möchte.
+  - Mitarbeit an allen Projekten (z.B. PRs auf GH, Beteiligung bei Teams etc.) ist erwünscht!
 - Aktives Mitglied:
-    - Beteiligt oder Beteiligte sich in den letzten Monaten aktiv an min. einem Projekt und nimmt regelmäßig an Sitzungen teil.
-    - Ist Member in der GitHub-Org (kann also insbesondere neue Repos erzeugen).
-    - Bekommt Zugriff auf weitere Dienste der FOSS-AG.
-    - Wird Mitgliedschaft im Orga-Chat angeboten.
+  - Beteiligt oder Beteiligte sich in den letzten Monaten aktiv an min. einem Projekt und nimmt regelmäßig an Sitzungen teil.
+  - Ist Member in der GitHub-Org (kann also insbesondere neue Repos erzeugen).
+  - Bekommt Zugriff auf weitere Dienste der FOSS-AG.
+  - Wird Mitgliedschaft im Orga-Chat angeboten.
 
 - Teams:
   - Haben 2-n Mitglieder:

--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -1,4 +1,7 @@
+# Guidelines Matrix
+
 Es gibt folgende Matrix-Räume:
+
 - FOSS-AG Hauptkanal (öffentlich)
   - Es gibt einen Admin
   - Jeder Aktive kann Moderator-Rechte erhalten
@@ -15,5 +18,5 @@ Es gibt folgende Matrix-Räume:
     - Keine allgemeinen Themen -> offener Kanal
 - Weitere Räume für Teams
 - Schema:
-  - Name: FOSS-AG <Titel>
+  - Name: `FOSS-AG <Titel>`
   - Logo: FOSS-AG Logo oder vom Grafik-Team angenickt

--- a/doc/guidelines_services.md
+++ b/doc/guidelines_services.md
@@ -1,3 +1,5 @@
+# Guidelines Services
+
 - Struktur für GitHub (Draft):
   - Siehe auch [Guidelines FOSS-AG](guidelines_foss-ag.md).
   - *Alternative 1*: Es gibt einen Owner-Account der keine natürlichen Person direkt zugeordnet ist. 3 Personen die darauf Zugriff haben (oder mit geteilter 2FA).
@@ -5,6 +7,7 @@
     - Owner halten sich an die Konventionen der Teams (z.B. Commits per PR)
   - Aktive Personen sind Member.
     - Können Team-Relevante Repos nach eigenem Ermessen erstellen.
+
 - Namensschema für GitHub:
   - Festgelegt in Sitzung '2017-07-21 Sitzung Nr 46'.
   - `<kategorie>_<titel>-<der>-<veranstaltung>`
@@ -17,7 +20,7 @@
 - Auswahl der Git-Plattform
   - GitHub für normale und öffentliche Repos.
   - Gitea für interne und private Repos.
-  
+
 - NextCloud:
   - Jede aktive Person kann einen Account für FOSS-AG Dinge bekommen
   - Datenschutz muss gewahrt werden


### PR DESCRIPTION
Hier sind nur Formatierungssachen drin, über die `markdownlint` gemeckert hat.
Unter anderem haben alle Dateien nun echte Überschriften.