### PR TITLE
Update orga-chat guideline

### DIFF
--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -9,7 +9,7 @@ Es gibt folgende Matrix-Räume:
     - FOSS-AG Aktivitäten
     - FOSS-Themen
     - Vorstellung von Teams, Events, etc.
-- FOSS-AG Orga (nur aktive Mitglieder)
+- FOSS-AG Orga (wenn es keine Einwände gibt, jeder der möchte)
   - Es gibt einen Admin
   - Themen:
     - Absprache von Terminfindungen/Raumorganisation


### PR DESCRIPTION
Die Idee des Orga-Chat war es, datenschutzrelevante oder rein organisatorische Dinge zu klären, nicht sich irgendwie abzugrenzen.

Darauf haben mich Jan und Chris auch nochmal hingewiesen - insofern ist dieser Zusatz eigentlich doof. Deswegen schlage ich folgende Änderung vor.