### PR TITLE
Entfernung der 'Aktiven' Rolle, neue Kanäle, Trennung der Dienstberechtigungen

### DIFF
--- a/doc/guidelines_foss-ag.md
+++ b/doc/guidelines_foss-ag.md
@@ -2,24 +2,22 @@
 
 Es gibt folgende Rollen einer Person:
 
-- Mitglied/Besucher:
-  - Jeder der möchte.
+- **Mitglied**:
+  - Jeder der irgendwie mitmacht
   - Mitarbeit an allen Projekten (z.B. PRs auf GH, Beteiligung bei Teams etc.) ist erwünscht!
-- Aktives Mitglied:
-  - Beteiligt oder Beteiligte sich in den letzten Monaten aktiv an min. einem Projekt und nimmt regelmäßig an Sitzungen teil.
-  - Ist Member in der GitHub-Organisation. (kann also insbesondere neue Repos erzeugen)
-  - Bekommt Zugriff auf weitere Dienste der FOSS-AG.
-  - Wird Mitgliedschaft im Orga-Chat angeboten.
+- **Stimmberechtigt**:
+  - Jeder kann Stimmrecht beantragen. Es gibt ein Veto-Recht von existierenden Mitgliedern.
+  - Bei Abstimmungen welche die ganze FOSS-AG Betreffen, sollen nur Stimmberechtigte mit bestimmen.
 
-- Teams:
-  - Haben 2-n Mitglieder:
+- **Teams**:
+  - Haben 2-n **Mitglieder**:
     - Haben nur Read-Rechte auf Repos des Teams. -> PRs sind der Default.
-  - Haben 2-n Maintainer (sollten nicht zu viele werden):
+  - Haben 2-n **Maintainer** (sollten nicht zu viele werden):
     - Haben Admin-Rechte im GitHub-Team und allen Repos des Teams.
     - Sind also insbesondere fürs Mergen von PRs zuständig.
     - Dürfen aber Repo-Rechte beliebig setzen. -> Wir geben nichts vor.
     - Sind Admin im Team-Chat.
-  - Haben 1-n Ansprechpartner für Interessierte.
+  - Haben 1-n **Ansprechpartner für Interessierte**:
     - Müssen nicht Teilmenge der Maintainer sein.
     - Werden im Wiki aufgelistet.
     - Sollen die im Team üblichen Konventionen kennen.

--- a/doc/guidelines_foss-ag.md
+++ b/doc/guidelines_foss-ag.md
@@ -3,11 +3,11 @@
 Es gibt folgende Rollen einer Person:
 
 - **Mitglied**:
-  - Jeder der irgendwie mitmacht
+  - Jeder der mitmacht
   - Mitarbeit an allen Projekten (z.B. PRs auf GH, Beteiligung bei Teams etc.) ist erwünscht!
 - **Stimmberechtigt**:
   - Jeder kann Stimmrecht beantragen. Es gibt ein Veto-Recht von existierenden Mitgliedern.
-  - Bei Abstimmungen welche die ganze FOSS-AG Betreffen, sollen nur Stimmberechtigte mit bestimmen.
+  - Bei Abstimmungen welche die ganze FOSS-AG betreffen, sollen nur Stimmberechtigte mit bestimmen.
 
 - **Teams**:
   - Haben 2-n **Mitglieder**:

--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -4,17 +4,23 @@ Es gibt folgende Matrix-Räume:
 
 - FOSS-AG Hauptkanal (öffentlich)
   - Es gibt einen Admin
-  - Jedes aktive Mitglied kann Moderator-Rechte erhalten
+  - Jeder kann auf Anfrage Moderator-Rechte erhalten. Vetorecht unter Stimmberechtigten.
   - Themen:
-    - FOSS-AG Aktivitäten
+    - Allgemeine FOSS-AG Aktivitäten
     - FOSS-Themen
     - Vorstellung von Teams, Events, etc.
-- FOSS-AG Orga (nur aktive Mitglieder)
+- FOSS-AG Organisation (öffentlich)
   - Es gibt einen Admin
   - Themen:
-    - Absprache von Terminfindungen/Raumorganisation
-    - Vorschlagen potentieller neuer aktiver Mitglieder -> Aufnahme nach Abstimmung mit weiteren aktiven Mitgliedern
+	- Projektplanungen
+	- Terminplanungen
+    - Raumorganisation
+	- Kaffeeorganisation
+	- Alles Organisatorische
+  - Jeder der möchte kann dort hinein
+- FOSS-AG Privat (invite only)
     - Diskussionen die persönliche Daten enthalten (z.B. Roh-Fotos von Events)
+    - Nur nach Absprache mit Vetorecht unter Stimmberechtigten.
     - Keine allgemeinen Themen -> offener Kanal
 - Weitere Räume für Teams
 - Schema:

--- a/doc/guidelines_matrix.md
+++ b/doc/guidelines_matrix.md
@@ -12,16 +12,11 @@ Es gibt folgende Matrix-Räume:
 - FOSS-AG Organisation (öffentlich)
   - Es gibt einen Admin
   - Themen:
-	- Projektplanungen
-	- Terminplanungen
+    - Projektplanungen
+    - Terminplanungen
     - Raumorganisation
-	- Kaffeeorganisation
-	- Alles Organisatorische
-  - Jeder der möchte kann dort hinein
-- FOSS-AG Privat (invite only)
-    - Diskussionen die persönliche Daten enthalten (z.B. Roh-Fotos von Events)
-    - Nur nach Absprache mit Vetorecht unter Stimmberechtigten.
-    - Keine allgemeinen Themen -> offener Kanal
+    - Kaffeeorganisation
+    - Alles Organisatorische
 - Weitere Räume für Teams
 - Schema:
   - Name: `FOSS-AG <Titel>`

--- a/doc/guidelines_services.md
+++ b/doc/guidelines_services.md
@@ -2,16 +2,19 @@
 
 - Struktur für GitHub:
   - Siehe auch [Guidelines FOSS-AG](guidelines_foss-ag.md).
+  - Zugriff auf Anfrage bei Bedarf, wird nicht proaktiv vergeben.
   - Es gibt 3 Owner.
-    - Owner halten sich an die Konventionen der Teams (z.B. Commits per PR)
-  - Aktive Personen sind Member.
-    - Können Team-Relevante Repos nach eigenem Ermessen erstellen.
+    - Owner halten sich an die Konventionen der Teams (z.B. Commits per PR).
+  - Maintainer der einzelnen Projekte können Selbststädnig Collaborator festlegen.
+  - Maintainer können Team-Relevante Repos nach eigenem Ermessen erstellen.
+  - Hinzufügen zur Organisation auf Anfrage mit Vetorecht unter Stimmberechtigten.
   - Namensschema:
     - Festgelegt in Sitzung '2017-07-21 Sitzung Nr 46'.
     - `<kategorie>_<titel>-<der>-<veranstaltung>`
 
 - Unser eigenes Gitea
-  - Jede Person kann auf Anfrage einen Account bekommen. Aktive Mitglieder werden dort Member der FOSS-AG Organisation.
+  - Jede Person kann auf Anfrage einen Account bekommen.
+  - Hinzufügen zur Organisation auf Anfrage mit Vetorecht unter Stimmberechtigten.
   - Jede Person kann nach eigenem Ermessen private und öffentliche Repositories erstellen.
   - Nicht FOSS-AG relevante Dinge sollten nicht unterhalb der FOSS-AG Organisation erstellt werden.
 
@@ -20,6 +23,6 @@
   - Gitea für interne und private Repos.
 
 - NextCloud:
-  - Jede aktive Person kann einen Account für FOSS-AG Dinge bekommen
+  - Jede Person kann auf Anfrage einen Account für FOSS-AG Dinge bekommen mit Vetorecht unter Stimmberechtigten
   - Datenschutz muss gewahrt werden
   - Es gibt einen öffentlichen [Kalender](https://cloud.foss-ag.de/index.php/apps/calendar/p/Rs4BXqPkfyxJa2QK/FOSS-AG).


### PR DESCRIPTION
Stattdessen gibt es Stimmberechtigte und einen neuen, öffentlichen Organisationskanal.

Übernimmt die Vorschläge von Thief und Chef aus #31 und #32 bezüglich der Änderung (bzw. letztendlich Entfernung) der 'Aktiven' Rolle und übernimmt das Kanal-Layout von Draget aus #31.