### PR TITLE
Update calender link to fachschaften.org

### DIFF
--- a/doc/guidelines_services.md
+++ b/doc/guidelines_services.md
@@ -22,4 +22,4 @@
 - NextCloud:
   - Jeder kann einen Account anfragen.
   - Datenschutz muss gewahrt werden.
-  - Es gibt einen öffentlichen [Kalender](https://cloud.foss-ag.de/index.php/apps/calendar/p/Rs4BXqPkfyxJa2QK/FOSS-AG).
+  - Es gibt einen öffentlichen [Kalender](https://cloud.fachschaften.org/index.php/apps/calendar/p/CX66qJFsw6GR6KYy/FOSS-AG).


### PR DESCRIPTION
In Sitzung 146 we created a new shared nextcloud calender with the fachschaften.org cloud.